### PR TITLE
Fix Dead DDR bug

### DIFF
--- a/Assets/Scripts/LevelManager.cs
+++ b/Assets/Scripts/LevelManager.cs
@@ -166,6 +166,7 @@ public class LevelManager : MonoBehaviour
             Cursor.visible = true;
             Cursor.lockState = CursorLockMode.None;
             reloadLevelUI.SetActive(true);
+            currentGameState = GameState.DEAD;
         }
     }
 

--- a/Assets/Scripts/Player/PlayerControl.cs
+++ b/Assets/Scripts/Player/PlayerControl.cs
@@ -42,6 +42,7 @@ namespace Player
         private Vector3 move;
 
         private InputManager inputManager;
+        private LevelManager lm;
         private bool cameraStarted = false;
         private AudioSource buzzSfx;
 
@@ -61,6 +62,7 @@ namespace Player
             controller = GetComponent<CharacterController>();
             powerup = GetComponent<PlayerPowerupBehavior>();
             inputManager = FindObjectOfType<InputManager>();
+            lm = FindObjectOfType<LevelManager>();
             buzzSfx = GetComponent<AudioSource>();
             buzzSfx.Play();
             
@@ -78,7 +80,7 @@ namespace Player
                 camera.Follow(); // camera looks laggy if we just call Follow in PlayerCamera.Update()/LateUpdate()/FixedUpdate()
             }
 
-            if (!LevelManager.gamePaused && ! NPCInteract.interacting)
+            if (!LevelManager.gamePaused && ! NPCInteract.interacting && lm.currentGameState != GameState.DEAD)
             {
                 Vector2 mouseInput = inputManager.GetMouseAxes();
                 switch (currState)

--- a/Assets/Scripts/Player/StingBehavior.cs
+++ b/Assets/Scripts/Player/StingBehavior.cs
@@ -20,6 +20,7 @@ namespace Enemies
 
         private PlayerPowerupBehavior powerup;
         private InputManager input;
+        private LevelManager lm;
 
         private bool stinging = false;
 
@@ -29,6 +30,7 @@ namespace Enemies
             wasps = GameObject.FindGameObjectsWithTag("Enemy");
             input = FindObjectOfType<InputManager>();
             powerup = GetComponent<PlayerPowerupBehavior>();
+            lm = FindObjectOfType<LevelManager>();
         }
 
         // Update is called once per frame
@@ -36,7 +38,11 @@ namespace Enemies
         {
             if (WaspInRange() && input.GetStingKeyClicked() && !LevelManager.gamePaused)
             {
-                StingEnemy();
+                if(lm.currentGameState != GameState.DEAD)
+                {
+                    StingEnemy();
+
+                }
             } 
             else if (stinging)
             {


### PR DESCRIPTION
- when you die in level 2 and 3 you could keep pressing q and play DDR if you're near an enemy
- fixed this bug and also stopped the player bee from flying during the "Restart Level" screen